### PR TITLE
feat: replace gengithubactions with Dagger gen-role-files

### DIFF
--- a/ansible-test-role.yml
+++ b/ansible-test-role.yml
@@ -24,7 +24,12 @@ tasks:
     cmds:
       - |
         cd {{ .dir | quote }};
-        gengithubactions;
+        dagger call \
+          --mod github.com/andrewrothstein/docker-ansible@develop \
+          gen-role-files \
+          --role-name=$(basename {{ .dir | quote }}) \
+          --role-dir=. \
+          export --path=.;
         if [ -e "requirements.txt" ];
         then
           git rm -f requirements.txt


### PR DESCRIPTION
## Summary
- Replaces the Python-based `gengithubactions` tool with the new Dagger `gen-role-files` function
- docker-ansible is now the single source of truth for platform versions

## Changes
- Updates `sauce` task in `ansible-test-role.yml` to use:
  ```bash
  dagger call \
    --mod github.com/andrewrothstein/docker-ansible@develop \
    gen-role-files \
    --role-name=$(basename $dir) \
    --role-dir=. \
    export --path=.
  ```

## Test plan
- [ ] Run `task ansible-test-role:clone name=k3s` to verify the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)