### PR TITLE
feat: migrate default task to use Dagger test-role

### DIFF
--- a/ansible-test-role.yml
+++ b/ansible-test-role.yml
@@ -95,29 +95,18 @@ tasks:
     vars:
       OS: '{{ .OS | default "debian" }}'
       OS_VER: '{{ .OS_VER | default "bookworm" }}'
-      BAKE_TARGET: '{{ .BAKE_TARGET | default "default" }}'
-      PUSH: '{{ .PUSH | default "false" }}'
-      PROGRESS: '{{ .PROGRESS | default "plain" }}'
+      PLATFORMS: '{{ .PLATFORMS | default "linux/amd64" }}'
       ROLE_DIR: '{{ .ROLE_DIR | default .USER_WORKING_DIR }}'
-      TAG: 0.0.0-{{ .OS }}.{{ .OS_VER }}
-      BAKEFILE: https://github.com/andrewrothstein/bake-ansible-images-v1.git#develop
-    env:
-      UPSTREAM_TAG: '{{ .TAG }}'
-      TARGET_TAG: '{{ .TAG }}'
     cmds:
-      - |-
+      - |
         cd {{ .ROLE_DIR | quote }};
-        export TARGET_SLUG=$(basename {{ .ROLE_DIR | quote }})
-        docker \
-          buildx bake \
-            {{ .BAKEFILE | quote }} \
-            {{ .BAKE_TARGET | quote }}
-            {{- if eq .PUSH "true" }} \
-            --push
-            {{- end }}
-            {{- if .PROGRESS }} \
-            --progress {{ .PROGRESS | quote }}
-            {{- end }}
+        dagger call \
+          --mod github.com/andrewrothstein/docker-ansible@develop \
+          test-role \
+          --os={{ .OS | quote }} \
+          --os-ver={{ .OS_VER | quote }} \
+          --role-dir=. \
+          --platforms={{ .PLATFORMS | quote }}
   checksums:
     internal: true
     vars:


### PR DESCRIPTION
## Summary
Replaces docker buildx bake with Dagger test-role function for testing Ansible roles locally.

## Changes
- Removed BAKE_TARGET, PUSH, PROGRESS, TAG, BAKEFILE variables
- Added PLATFORMS variable (defaults to linux/amd64)
- Uses `dagger call test-role` instead of `docker buildx bake`

## Usage
```bash
# Test on Debian bookworm (default)
task ansible-test-role:default

# Test on Ubuntu noble
task ansible-test-role:default OS=ubuntu OS_VER=noble

# Test on multiple platforms
task ansible-test-role:default OS=alpine OS_VER=3.23 PLATFORMS=linux/amd64,linux/arm64
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)