### PR TITLE
Add npm, npx, and playwright task modules

### DIFF
--- a/npm.yml
+++ b/npm.yml
@@ -1,0 +1,102 @@
+---
+version: '3'
+tasks:
+  default:
+    desc: Run npm with arbitrary arguments
+    vars:
+      npm_exe: '{{ .npm_exe | default "npm" }}'
+      npm_args: '{{ .npm_args }}'
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - '{{ .npm_exe }} {{ .npm_args }}'
+
+  install:
+    desc: Install npm dependencies
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      pkg: '{{ .pkg }}'
+      dev: '{{ .dev | default "false" }}'
+      global: '{{ .global | default "false" }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          npm_args: |-
+            install
+            {{- if eq "true" .global }} \
+              --global
+            {{- end }}
+            {{- if eq "true" .dev }} \
+              --save-dev
+            {{- end }}
+            {{- if .pkg }} \
+              {{ .pkg }}
+            {{- end }}
+
+  ci:
+    desc: Clean install from package-lock.json
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          npm_args: ci
+
+  run:
+    desc: Run an npm script
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      script: '{{ .script }}'
+      script_args: '{{ .script_args }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          npm_args: |-
+            run {{ .script }}
+            {{- if .script_args }} \
+              -- {{ .script_args }}
+            {{- end }}
+
+  test:
+    desc: Run npm test
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          npm_args: test
+
+  build:
+    desc: Run npm build script
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: run
+        vars:
+          dir: '{{ .dir }}'
+          script: build
+
+  init:
+    desc: Initialize a new package.json
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      yes: '{{ .yes | default "false" }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          npm_args: |-
+            init
+            {{- if eq "true" .yes }} \
+              --yes
+            {{- end }}

--- a/npx.yml
+++ b/npx.yml
@@ -1,0 +1,60 @@
+---
+version: '3'
+tasks:
+  default:
+    desc: Run npx with arbitrary arguments
+    vars:
+      npx_exe: '{{ .npx_exe | default "npx" }}'
+      npx_args: '{{ .npx_args }}'
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      pkg: '{{ .pkg }}'
+      yes: '{{ .yes | default "false" }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - |-
+        {{ .npx_exe }}
+        {{- if eq "true" .yes }} \
+          --yes
+        {{- end }}
+        {{- if .pkg }} \
+          {{ .pkg }}
+        {{- end }}
+        {{- if .npx_args }} \
+          {{ .npx_args }}
+        {{- end }}
+
+  run:
+    desc: Run a package with npx
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      pkg: '{{ .pkg }}'
+      pkg_args: '{{ .pkg_args }}'
+      yes: '{{ .yes | default "false" }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          pkg: '{{ .pkg }}'
+          yes: '{{ .yes }}'
+          npx_args: '{{ .pkg_args }}'
+
+  create:
+    desc: Run create-* scaffolding tools (e.g., create-vite, create-react-app)
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      template: '{{ .template }}'
+      project_name: '{{ .project_name }}'
+      template_args: '{{ .template_args }}'
+    dir: '{{ .dir }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          yes: 'true'
+          pkg: '{{ .template }}@latest'
+          npx_args: |-
+            {{ .project_name }}
+            {{- if .template_args }} \
+              {{ .template_args }}
+            {{- end }}

--- a/playwright.yml
+++ b/playwright.yml
@@ -1,0 +1,130 @@
+---
+version: '3'
+includes:
+  npx:
+    internal: true
+    taskfile: npx.yml
+  npm:
+    internal: true
+    taskfile: npm.yml
+tasks:
+  default:
+    desc: Run playwright with arbitrary arguments
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      playwright_args: '{{ .playwright_args }}'
+    cmds:
+      - task: npx:run
+        vars:
+          dir: '{{ .dir }}'
+          pkg: playwright
+          pkg_args: '{{ .playwright_args }}'
+
+  install:
+    desc: Install Playwright and browsers
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      browsers: '{{ .browsers | default "chromium" }}'
+    cmds:
+      - task: npm:install
+        vars:
+          dir: '{{ .dir }}'
+          pkg: '@playwright/test'
+          dev: 'true'
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          playwright_args: 'install {{ .browsers }}'
+
+  test:
+    desc: Run Playwright tests
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      project: '{{ .project }}'
+      workers: '{{ .workers }}'
+      headed: '{{ .headed | default "false" }}'
+      debug: '{{ .debug | default "false" }}'
+      grep: '{{ .grep }}'
+      test_file: '{{ .test_file }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          playwright_args: |-
+            test
+            {{- if .project }} \
+              --project={{ .project }}
+            {{- end }}
+            {{- if .workers }} \
+              --workers={{ .workers }}
+            {{- end }}
+            {{- if eq "true" .headed }} \
+              --headed
+            {{- end }}
+            {{- if eq "true" .debug }} \
+              --debug
+            {{- end }}
+            {{- if .grep }} \
+              --grep {{ .grep | quote }}
+            {{- end }}
+            {{- if .test_file }} \
+              {{ .test_file }}
+            {{- end }}
+
+  test:ui:
+    desc: Run Playwright tests in UI mode
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          playwright_args: 'test --ui'
+
+  test:headed:
+    desc: Run Playwright tests with visible browser
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      workers: '{{ .workers | default "1" }}'
+    cmds:
+      - task: test
+        vars:
+          dir: '{{ .dir }}'
+          headed: 'true'
+          workers: '{{ .workers }}'
+
+  codegen:
+    desc: Generate tests by recording browser actions
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      url: '{{ .url }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          playwright_args: |-
+            codegen
+            {{- if .url }} \
+              {{ .url }}
+            {{- end }}
+
+  show-report:
+    desc: Open the HTML test report
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          playwright_args: 'show-report'
+
+  trace:
+    desc: Show trace viewer for a trace file
+    vars:
+      dir: '{{ .dir | default .USER_WORKING_DIR }}'
+      trace_file: '{{ .trace_file }}'
+    cmds:
+      - task: default
+        vars:
+          dir: '{{ .dir }}'
+          playwright_args: 'show-trace {{ .trace_file }}'


### PR DESCRIPTION
## Summary
- Add reusable Taskfile modules for Node.js/Playwright workflows:
  - `npm.yml`: npm wrapper tasks (install, ci, run, test, build, init)
  - `npx.yml`: npx wrapper tasks (run, create for scaffolding)
  - `playwright.yml`: Playwright E2E testing tasks (install, test, codegen, trace)

## Usage
```bash
task npm:install pkg=lodash dev=true
task npx:create template=create-vite project_name=my-app
task playwright:test headed=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)