### PR TITLE
Embrace Helm 4 SSA: force-conflicts + template-apply for CRD charts

### DIFF
--- a/cert-manager.yml
+++ b/cert-manager.yml
@@ -25,7 +25,7 @@ includes:
       chart_ver: v1.20.0
       chart: cert-manager
       helm_args: -f cert-manager-values.yml
-      server_side: 'false'
+      force_conflicts: 'true'
   approver_policy:
     taskfile: helm.yml
     vars:

--- a/envoygateway.yml
+++ b/envoygateway.yml
@@ -62,18 +62,18 @@ tasks:
   upgrade:
     cmds:
       - task: gwkk:ns-create
-      - task: gw-crds:upgrade
+      - task: gw-crds:template-apply
       - task: gw:upgrade
       - task: aigwkk:ns-create
-      - task: aigw-crds:upgrade
+      - task: aigw-crds:template-apply
       - task: aigw:upgrade
   delete:
     cmds:
       - task: aigw:delete
-      - task: aigw-crds:delete
+      - task: aigw-crds:template-delete
       - task: aigwkk:ns-delete
       - task: gw:delete
-      - task: gw-crds:delete
+      - task: gw-crds:template-delete
       - task: gwkk:ns-delete
   check:
     cmds:

--- a/helm.yml
+++ b/helm.yml
@@ -31,7 +31,7 @@ tasks:
       chart_ver: '{{ .chart_ver }}'
       wait: '{{ .wait | default "true" }}'
       timeout: '{{ .timeout | default "10m" }}'
-      server_side: '{{ .server_side | default "true" }}'
+      force_conflicts: '{{ .force_conflicts | default "false" }}'
       skip_crds: '{{ .skip_crds | default "false" }}'
       helm_args: '{{ .helm_args | default "" }}'
     cmds:
@@ -47,8 +47,8 @@ tasks:
           {{- if eq "true" .create_namespace }}  \
           --create-namespace
           {{- end }}
-          {{- if eq "false" .server_side }} \
-          --server-side=false
+          {{- if eq "true" .force_conflicts }} \
+          --force-conflicts
           {{- end }}
           {{- if eq "true" .skip_crds }} \
           --skip-crds
@@ -65,6 +65,58 @@ tasks:
           {{- if .helm_args }} \
           {{ .helm_args }}
           {{- end }}
+  template-apply:
+    desc: "Render chart with helm template and apply via kubectl server-side apply (bypasses release Secret size limit)"
+    vars:
+      namespace: '{{ .namespace }}'
+      name: '{{ .name }}'
+      chart_repo_name: '{{ .chart_repo_name }}'
+      chart: '{{ .chart }}'
+      chart_ver: '{{ .chart_ver }}'
+      helm_args: '{{ .helm_args | default "" }}'
+    cmds:
+      - |-
+        helm \
+          template \
+          {{ .name | quote }} \
+          "{{ if .chart_repo_name }}{{ .chart_repo_name }}/
+          {{- end }}{{ .chart }}"
+          {{- if .chart_ver }} \
+          --version {{ .chart_ver | quote }}
+          {{- end }}
+          {{- if .namespace }} \
+          -n {{ .namespace | quote }}
+          {{- end }}
+          {{- if .helm_args }} \
+          {{ .helm_args }}
+          {{- end }} \
+          | kubectl apply --server-side --force-conflicts -f -
+  template-delete:
+    desc: "Render chart with helm template and delete via kubectl"
+    vars:
+      namespace: '{{ .namespace }}'
+      name: '{{ .name }}'
+      chart_repo_name: '{{ .chart_repo_name }}'
+      chart: '{{ .chart }}'
+      chart_ver: '{{ .chart_ver }}'
+      helm_args: '{{ .helm_args | default "" }}'
+    cmds:
+      - |-
+        helm \
+          template \
+          {{ .name | quote }} \
+          "{{ if .chart_repo_name }}{{ .chart_repo_name }}/
+          {{- end }}{{ .chart }}"
+          {{- if .chart_ver }} \
+          --version {{ .chart_ver | quote }}
+          {{- end }}
+          {{- if .namespace }} \
+          -n {{ .namespace | quote }}
+          {{- end }}
+          {{- if .helm_args }} \
+          {{ .helm_args }}
+          {{- end }} \
+          | kubectl delete --ignore-not-found -f -
   install:
     vars:
       namespace: '{{ .namespace }}'

--- a/istio.yml
+++ b/istio.yml
@@ -13,7 +13,7 @@ includes:
       chart_repo_name: istio
       chart: ambient
       chart_ver: '{{ .istio_ver }}'
-      server_side: 'false'
+      force_conflicts: 'true'
       helm_args: -f istio-ambient-values.yml
 tasks:
   default:

--- a/openbao.yml
+++ b/openbao.yml
@@ -16,7 +16,7 @@ includes:
       chart_repo_name: openbao
       chart: openbao
       chart_ver: 0.26.1
-      server_side: 'false'
+      force_conflicts: 'true'
       helm_args: >-
         -f openbao-values.yml
         --set server.dev.devRootToken="${VAULT_ROOT_TOKEN}"

--- a/pxc-operator.yml
+++ b/pxc-operator.yml
@@ -15,7 +15,7 @@ includes:
       chart_ver: 1.19.0
       namespace: pxc-operator
       name: pxc-operator
-      server_side: 'false'
+      force_conflicts: 'true'
       helm_args: -f pxc-operator-values.yml
 tasks:
   default:

--- a/vault.yml
+++ b/vault.yml
@@ -28,7 +28,7 @@ includes:
       chart_ver: 0.32.0
       namespace: vault-system
       name: vault
-      server_side: 'false'
+      force_conflicts: 'true'
   ingress:
     taskfile: tailscale-ingress.yml
     vars:


### PR DESCRIPTION
## Summary
- **Remove `server_side: 'false'` workarounds** from istio, cert-manager, vault, openbao, pxc-operator — SSA is Helm 4's default, these were disabled out of fear of ownership conflicts
- **Add `force_conflicts` option** to `helm.yml` upgrade task so Helm properly takes field ownership via `--force-conflicts`
- **Add `template-apply`/`template-delete` tasks** to `helm.yml` — renders charts with `helm template` and applies via `kubectl apply --server-side --force-conflicts`, bypassing the 1MB etcd Secret size limit for CRD-heavy charts
- **Switch envoy-gateway and ai-gateway CRD charts** to `template-apply` to fix the `Too long: may not be more than 1048576 bytes` error

## Test plan
- [x] `task delete` (clean teardown of existing cluster)
- [x] `task up` from scratch — all charts deployed successfully, exit code 0
- [x] No errors in full deployment output
- [x] `uvx pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)