### PR TITLE
Add self-hosted Temporal.io deployment

### DIFF
--- a/post-mesh-2.yml
+++ b/post-mesh-2.yml
@@ -6,6 +6,7 @@ vars:
   airflow: pet
   retool: pet
   hatchet: hatchet
+  temporal: temporal
 includes:
   pinniped-supervisor:
     taskfile: '{{ .pinniped_supervisor }}.yml'
@@ -22,6 +23,9 @@ includes:
   hatchet:
     taskfile: '{{ .hatchet }}.yml'
 
+  temporal:
+    taskfile: '{{ .temporal }}.yml'
+
 tasks:
   default:
     deps:
@@ -33,8 +37,10 @@ tasks:
       - task: airflow:upgrade
       - task: retool:upgrade
       - task: hatchet:upgrade
+      - task: temporal:upgrade
   delete:
     cmds:
+      - task: temporal:delete
       - task: hatchet:delete
       - task: retool:delete
       - task: airflow:delete
@@ -45,3 +51,4 @@ tasks:
       - task: airflow:check
       - task: retool:check
       - task: hatchet:check
+      - task: temporal:check

--- a/temporal-repo.yml
+++ b/temporal-repo.yml
@@ -1,0 +1,12 @@
+---
+version: '3'
+includes:
+  helm-repo:
+    taskfile: helm-repo.yml
+    vars:
+      n: temporalio
+      url: https://temporalio.github.io/helm-charts
+tasks:
+  default:
+    deps:
+      - task: helm-repo:add

--- a/temporal-tailscale-ingress-values.yml
+++ b/temporal-tailscale-ingress-values.yml
@@ -1,0 +1,10 @@
+---
+gateways:
+  - name: temporal
+    host: temporal
+    routes:
+      - path: /
+        service:
+          name: temporal-web
+          port:
+            number: 8080

--- a/temporal-values.yml
+++ b/temporal-values.yml
@@ -1,0 +1,60 @@
+---
+server:
+  replicaCount: 1
+  config:
+    namespaces:
+      create: true
+      namespace:
+        - name: default
+          retention: 3d
+    persistence:
+      default:
+        driver: sql
+        sql:
+          driver: postgres12
+          host: temporal-pg-chart-cnpg-instance-rw
+          port: 5432
+          database: temporal
+          user: temporal
+          password: temporal
+          existingSecret: temporal-pg-user
+          secretName: password
+      visibility:
+        driver: sql
+        sql:
+          driver: postgres12
+          host: temporal-pg-chart-cnpg-instance-rw
+          port: 5432
+          database: temporal_visibility
+          user: temporal
+          password: temporal
+          existingSecret: temporal-pg-user
+          secretName: password
+
+schema:
+  createDatabase:
+    enabled: false
+
+web:
+  enabled: true
+
+admintools:
+  enabled: true
+
+cassandra:
+  enabled: false
+
+mysql:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+elasticsearch:
+  enabled: false
+
+prometheus:
+  enabled: false
+
+grafana:
+  enabled: false

--- a/temporal.yml
+++ b/temporal.yml
@@ -1,0 +1,92 @@
+---
+version: '3'
+includes:
+  repo: temporal-repo.yml
+  kk:
+    taskfile: kubectl.yml
+    vars:
+      n: temporal
+  pg-secret:
+    taskfile: k8s-literal-secret.yml
+    vars:
+      n: temporal
+      s: temporal-pg-user
+  pg:
+    taskfile: helm.yml
+    vars:
+      namespace: temporal
+      name: temporal-pg
+      chart: chart-cnpg-instance
+      helm_args: >-
+        --set instances=1
+        --set storage.size=10Gi
+        --set bootstrap.initdb.database=temporal
+        --set bootstrap.initdb.owner=temporal
+        --set bootstrap.initdb.secret.name=temporal-pg-user
+        --set 'bootstrap.initdb.postInitSQL[0]=CREATE DATABASE temporal_visibility OWNER temporal'
+  helm:
+    taskfile: helm.yml
+    vars:
+      chart_repo_name: temporalio
+      chart: temporal
+      chart_ver: 0.73.2
+      namespace: temporal
+      name: temporal
+      timeout: 15m
+      helm_args: -f temporal-values.yml
+  ingress:
+    taskfile: tailscale-ingress.yml
+    vars:
+      namespace: temporal
+      name: temporal-tailscale-ingress
+      helm_args: -f temporal-tailscale-ingress-values.yml
+tasks:
+  pg-wait:
+    vars:
+      cluster_name: temporal-pg-chart-cnpg-instance
+    cmds:
+      - >-
+        kubectl wait clusters.postgresql.cnpg.io/{{ .cluster_name }}
+        -n temporal
+        --for=condition=Ready
+        --timeout=10m
+  test-secrets:
+    vars:
+      admin_password: '{{ .admin_password | default "${TEMPORAL_POSTGRESQL_PASSWORD}" }}'
+    cmds:
+      - test {{ .admin_password }}
+  default:
+    cmds:
+      - task: upgrade
+  upgrade:
+    vars:
+      admin_username: '{{ .admin_username | default "temporal" }}'
+      admin_password: '{{ .admin_password | default "${TEMPORAL_POSTGRESQL_PASSWORD}" }}'
+    deps:
+      - task: repo
+    cmds:
+      - task: test-secrets
+        vars:
+          admin_password: '{{ .admin_password }}'
+      - task: kk:ns-create
+      - task: pg-secret:create
+        vars:
+          args: >-
+            --from-literal=username={{ .admin_username }}
+            --from-literal=password={{ .admin_password }}
+      - task: pg:upgrade
+      - task: pg-wait
+      - task: helm:upgrade
+      - task: ingress:upgrade
+  delete:
+    cmds:
+      - task: ingress:delete
+      - task: helm:delete
+      - task: pg:delete
+      - task: pg-secret:delete
+      - task: kk:ns-delete
+  check:
+    deps:
+      - task: repo
+    cmds:
+      - task: helm:check


### PR DESCRIPTION
## Summary
- Add Temporal.io taskfile modules with CNPG PostgreSQL backend (no bundled sub-chart PG)
- Helm repo, values, and tailscale ingress for the Web UI
- Wire into post-mesh-2 deployment chain
- Declarative namespace management via values file

## Test plan
- [x] `doppler run --mount .env -- task post-mesh-2:temporal:upgrade` deploys successfully
- [x] CNPG cluster healthy, schema migration completes
- [x] All Temporal pods running (frontend, history, matching, worker, web, admintools)
- [x] Tailscale ingress routes to Web UI
- [x] Namespace creation works via values config

🤖 Generated with [Claude Code](https://claude.com/claude-code)