### PR TITLE
Replace MinIO with SeaweedFS, add barman cloud plugin

### DIFF
--- a/chart-cnpg-instance/templates/cluster.yml
+++ b/chart-cnpg-instance/templates/cluster.yml
@@ -147,6 +147,11 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
+  {{- with .Values.plugins }}
+  plugins:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.serviceAccountTemplate }}
   serviceAccountTemplate:
     {{- toYaml . | nindent 4 }}

--- a/chart-cnpg-instance/templates/objectstore.yml
+++ b/chart-cnpg-instance/templates/objectstore.yml
@@ -1,0 +1,30 @@
+{{- with .Values.objectStore }}
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ include "chart-cnpg-instance.fullname" $ }}-backup
+  labels:
+    {{- include "chart-cnpg-instance.labels" $ | nindent 4 }}
+spec:
+  configuration:
+    destinationPath: {{ .destinationPath | quote }}
+    {{- with .endpointURL }}
+    endpointURL: {{ . | quote }}
+    {{- end }}
+    {{- with .s3Credentials }}
+    s3Credentials:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .wal }}
+    wal:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .data }}
+    data:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- with .retentionPolicy }}
+  retentionPolicy: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/chart-cnpg-instance/values.yaml
+++ b/chart-cnpg-instance/values.yaml
@@ -154,6 +154,28 @@ storage:
 #   inProgress: false
 #   reusePVC: true
 
+# Barman Cloud Plugin ObjectStore (creates ObjectStore CR)
+# objectStore:
+#   destinationPath: s3://bucket/path/
+#   endpointURL: http://s3.example.com:8333
+#   s3Credentials:
+#     accessKeyId:
+#       name: my-s3-secret
+#       key: ACCESS_KEY_ID
+#     secretAccessKey:
+#       name: my-s3-secret
+#       key: ACCESS_SECRET_KEY
+#   wal:
+#     compression: gzip
+#   retentionPolicy: 7d
+
+# Plugins configuration (CNPG-I plugin system)
+# plugins:
+#   - name: barman-cloud.cloudnative-pg.io
+#     isWALArchiver: true
+#     parameters:
+#       barmanObjectName: my-object-store
+
 # Helm overrides
 # nameOverride: ""
 # fullnameOverride: ""

--- a/cnpg.yml
+++ b/cnpg.yml
@@ -16,6 +16,14 @@ includes:
       namespace: cnpg-system
       name: cnpg
       helm_args: -f cnpg-values.yml
+  barman-cloud:
+    taskfile: helm.yml
+    vars:
+      chart_repo_name: cnpg
+      chart: plugin-barman-cloud
+      chart_ver: 0.5.0
+      namespace: cnpg-system
+      name: barman-cloud
   test-instance:
     taskfile: helm.yml
     vars:
@@ -35,6 +43,7 @@ tasks:
     cmds:
       - task: kk:ns-create
       - task: helm:upgrade
+      - task: barman-cloud:upgrade
   test:
     cmds:
       - task: test-instance:create
@@ -44,6 +53,7 @@ tasks:
       - task: test-cluster:ns-delete
   delete:
     cmds:
+      - task: barman-cloud:delete
       - task: helm:delete
       - task: kk:delete
   check:
@@ -51,3 +61,4 @@ tasks:
       - task: repo
     cmds:
       - task: helm:check
+      - task: barman-cloud:check

--- a/k8s-storage.yml
+++ b/k8s-storage.yml
@@ -6,8 +6,9 @@ vars:
   csi_driver_nfs: csi-driver-nfs
   csi_driver_smb: csi-driver-smb
   trident: pet
-  minio_operator: minio-operator
-  velero: pet
+  minio_operator: pet
+  seaweedfs: seaweedfs
+  velero: velero-seaweedfs
   openebs: pet
   piraeus_operator: pet
   dragonfly: dragonfly
@@ -30,6 +31,9 @@ includes:
 
   minio-operator:
     taskfile: '{{ .minio_operator }}.yml'
+
+  seaweedfs:
+    taskfile: '{{ .seaweedfs }}.yml'
 
   velero:
     taskfile: '{{ .velero }}.yml'
@@ -58,6 +62,7 @@ tasks:
       - task: csi-driver-smb:upgrade
       - task: trident:upgrade
       - task: minio-operator:upgrade
+      - task: seaweedfs:upgrade
       - task: velero:upgrade
       - task: openebs:upgrade
       - task: piraeus-operator:apply
@@ -70,6 +75,7 @@ tasks:
       - task: piraeus-operator:delete
       - task: openebs:delete
       - task: velero:delete
+      - task: seaweedfs:delete
       - task: minio-operator:delete
       - task: trident:delete
       - task: csi-driver-smb:delete
@@ -84,6 +90,7 @@ tasks:
       - task: csi-driver-smb:check
       - task: trident:check
       - task: minio-operator:check
+      - task: seaweedfs:check
       - task: velero:check
       - task: openebs:check
       - task: piraeus-operator:check

--- a/seaweedfs-repo.yml
+++ b/seaweedfs-repo.yml
@@ -1,0 +1,12 @@
+---
+version: '3'
+includes:
+  helm-repo:
+    taskfile: helm-repo.yml
+    vars:
+      n: seaweedfs
+      url: https://seaweedfs.github.io/seaweedfs/helm
+tasks:
+  default:
+    deps:
+      - task: helm-repo:add

--- a/seaweedfs-values.yml
+++ b/seaweedfs-values.yml
@@ -1,0 +1,35 @@
+---
+master:
+  replicas: 1
+  data:
+    type: persistentVolumeClaim
+    size: 1Gi
+  logs:
+    type: persistentVolumeClaim
+    size: 1Gi
+
+volume:
+  replicas: 1
+  data:
+    type: persistentVolumeClaim
+    size: 10Gi
+  logs:
+    type: persistentVolumeClaim
+    size: 1Gi
+
+filer:
+  replicas: 1
+  data:
+    type: persistentVolumeClaim
+    size: 1Gi
+  logs:
+    type: persistentVolumeClaim
+    size: 1Gi
+
+s3:
+  enabled: true
+  enableAuth: true
+  existingConfigSecret: seaweedfs-s3-accounts
+  createBuckets:
+    - name: velero
+    - name: cnpg-temporal

--- a/seaweedfs.yml
+++ b/seaweedfs.yml
@@ -1,0 +1,86 @@
+---
+version: '3'
+includes:
+  repo: seaweedfs-repo.yml
+  kk:
+    taskfile: kubectl.yml
+    vars:
+      n: seaweedfs
+  helm:
+    taskfile: helm.yml
+    internal: true
+    vars:
+      chart_repo_name: seaweedfs
+      chart: seaweedfs
+      chart_ver: 4.17.0
+      namespace: seaweedfs
+      name: seaweedfs
+      timeout: 10m
+      helm_args: -f seaweedfs-values.yml
+tasks:
+  default:
+    cmds:
+      - task: upgrade
+  create-s3-accounts:
+    desc: "Generate S3 account credentials and config secret"
+    cmds:
+      - |
+        if kubectl get secret seaweedfs-s3-accounts -n seaweedfs >/dev/null 2>&1; then
+          echo "seaweedfs-s3-accounts secret already exists"
+          exit 0
+        fi
+        ADMIN_AK=$(openssl rand -hex 16)
+        ADMIN_SK=$(openssl rand -hex 32)
+        VELERO_AK=$(openssl rand -hex 16)
+        VELERO_SK=$(openssl rand -hex 32)
+        BARMAN_AK=$(openssl rand -hex 16)
+        BARMAN_SK=$(openssl rand -hex 32)
+        CONFIG=$(cat <<CONF
+        {
+          "identities": [
+            {
+              "name": "admin",
+              "credentials": [{"accessKey": "${ADMIN_AK}", "secretKey": "${ADMIN_SK}"}],
+              "actions": ["Admin", "Read", "Write"]
+            },
+            {
+              "name": "velero",
+              "credentials": [{"accessKey": "${VELERO_AK}", "secretKey": "${VELERO_SK}"}],
+              "actions": ["Read", "Write", "List"],
+              "buckets": ["velero"]
+            },
+            {
+              "name": "barman",
+              "credentials": [{"accessKey": "${BARMAN_AK}", "secretKey": "${BARMAN_SK}"}],
+              "actions": ["Read", "Write", "List"],
+              "buckets": ["cnpg-*"]
+            }
+          ]
+        }
+        CONF
+        )
+        kubectl create secret generic seaweedfs-s3-accounts \
+          -n seaweedfs \
+          --from-literal=seaweedfs_s3_config="${CONFIG}" \
+          --from-literal=admin_access_key_id="${ADMIN_AK}" \
+          --from-literal=admin_secret_access_key="${ADMIN_SK}" \
+          --from-literal=velero_access_key_id="${VELERO_AK}" \
+          --from-literal=velero_secret_access_key="${VELERO_SK}" \
+          --from-literal=barman_access_key_id="${BARMAN_AK}" \
+          --from-literal=barman_secret_access_key="${BARMAN_SK}"
+  upgrade:
+    deps:
+      - task: repo
+    cmds:
+      - task: kk:ns-create
+      - task: create-s3-accounts
+      - task: helm:upgrade
+  delete:
+    cmds:
+      - task: helm:delete
+      - task: kk:ns-delete
+  check:
+    deps:
+      - task: repo
+    cmds:
+      - task: helm:check

--- a/temporal.yml
+++ b/temporal.yml
@@ -11,6 +11,11 @@ includes:
     vars:
       n: temporal
       s: temporal-pg-user
+  pg-barman-s3-secret:
+    taskfile: k8s-literal-secret.yml
+    vars:
+      n: temporal
+      s: temporal-pg-barman-s3
   pg:
     taskfile: helm.yml
     vars:
@@ -24,6 +29,17 @@ includes:
         --set bootstrap.initdb.owner=temporal
         --set bootstrap.initdb.secret.name=temporal-pg-user
         --set 'bootstrap.initdb.postInitSQL[0]=CREATE DATABASE temporal_visibility OWNER temporal'
+        --set objectStore.destinationPath=s3://cnpg-temporal/
+        --set objectStore.endpointURL=http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
+        --set objectStore.s3Credentials.accessKeyId.name=temporal-pg-barman-s3
+        --set objectStore.s3Credentials.accessKeyId.key=ACCESS_KEY_ID
+        --set objectStore.s3Credentials.secretAccessKey.name=temporal-pg-barman-s3
+        --set objectStore.s3Credentials.secretAccessKey.key=ACCESS_SECRET_KEY
+        --set objectStore.wal.compression=gzip
+        --set objectStore.retentionPolicy=7d
+        --set 'plugins[0].name=barman-cloud.cloudnative-pg.io'
+        --set 'plugins[0].isWALArchiver=true'
+        --set 'plugins[0].parameters.barmanObjectName=temporal-pg-chart-cnpg-instance-backup'
   helm:
     taskfile: helm.yml
     vars:
@@ -50,6 +66,18 @@ tasks:
         -n temporal
         --for=condition=Ready
         --timeout=10m
+  create-pg-barman-s3-secret:
+    cmds:
+      - |
+        ACCESS_KEY=$(kubectl get secret seaweedfs-s3-accounts \
+          -n seaweedfs -o jsonpath='{.data.barman_access_key_id}' | base64 -d)
+        SECRET_KEY=$(kubectl get secret seaweedfs-s3-accounts \
+          -n seaweedfs -o jsonpath='{.data.barman_secret_access_key}' | base64 -d)
+        kubectl create secret generic temporal-pg-barman-s3 \
+          -n temporal \
+          --from-literal=ACCESS_KEY_ID="${ACCESS_KEY}" \
+          --from-literal=ACCESS_SECRET_KEY="${SECRET_KEY}" \
+          --dry-run=client -o yaml | kubectl apply -f -
   test-secrets:
     vars:
       admin_password: '{{ .admin_password | default "${TEMPORAL_POSTGRESQL_PASSWORD}" }}'
@@ -74,6 +102,7 @@ tasks:
           args: >-
             --from-literal=username={{ .admin_username }}
             --from-literal=password={{ .admin_password }}
+      - task: create-pg-barman-s3-secret
       - task: pg:upgrade
       - task: pg-wait
       - task: helm:upgrade
@@ -83,6 +112,7 @@ tasks:
       - task: ingress:delete
       - task: helm:delete
       - task: pg:delete
+      - task: pg-barman-s3-secret:delete
       - task: pg-secret:delete
       - task: kk:ns-delete
   check:

--- a/velero-seaweedfs-values.yml
+++ b/velero-seaweedfs-values.yml
@@ -1,0 +1,26 @@
+---
+configuration:
+  backupStorageLocation:
+    - name: default
+      provider: aws
+      bucket: velero
+      accessMode: ReadWrite
+      default: true
+      config:
+        region: us-east-1
+        s3ForcePathStyle: true
+        s3Url: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
+        publicUrl: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
+  volumeSnapshotLocation:
+    - name: my-volume-snapshot-location
+      provider: aws
+      config:
+        region: us-east-1
+initContainers:
+  - name: velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.14.0
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+credentials:
+  existingSecret: velero-seaweedfs-credentials

--- a/velero-seaweedfs.yml
+++ b/velero-seaweedfs.yml
@@ -1,0 +1,62 @@
+---
+version: '3'
+includes:
+  kk:
+    taskfile: kubectl.yml
+    vars:
+      n: velero
+      labels: 'istio.io/dataplane-mode=ambient'
+  velero-seaweedfs-credentials:
+    taskfile: k8s-literal-secret.yml
+    vars:
+      n: velero
+      s: velero-seaweedfs-credentials
+  repo: velero-repo.yml
+  helm:
+    taskfile: helm.yml
+    vars:
+      chart_repo_name: vmware-tanzu
+      chart: velero
+      chart_ver: 12.0.0
+      namespace: velero
+      name: velero
+      helm_args: -f velero-seaweedfs-values.yml
+tasks:
+  default:
+    deps:
+      - upgrade
+  create-velero-seaweedfs-credentials:
+    vars:
+      credentials_file: '{{ .credentials_file | default ".velero-seaweedfs-credentials" }}'
+    cmds:
+      - |
+        ACCESS_KEY=$(kubectl get secret seaweedfs-s3-accounts \
+          -n seaweedfs -o jsonpath='{.data.velero_access_key_id}' | base64 -d)
+        SECRET_KEY=$(kubectl get secret seaweedfs-s3-accounts \
+          -n seaweedfs -o jsonpath='{.data.velero_secret_access_key}' | base64 -d)
+        cat > {{ .credentials_file | quote }} <<HERE
+        [default]
+        aws_access_key_id=${ACCESS_KEY}
+        aws_secret_access_key=${SECRET_KEY}
+        HERE
+      - task: velero-seaweedfs-credentials:create
+        vars:
+          args: >-
+            --from-literal=cloud="$(cat {{ .credentials_file }})"
+  upgrade:
+    deps:
+      - task: repo
+    cmds:
+      - task: kk:ns-create
+      - task: create-velero-seaweedfs-credentials
+      - task: helm:upgrade
+  delete:
+    cmds:
+      - task: helm:delete
+      - task: velero-seaweedfs-credentials:delete
+      - task: kk:ns-delete
+  check:
+    deps:
+      - task: repo
+    cmds:
+      - task: helm:check


### PR DESCRIPTION
## Summary
- Add SeaweedFS (Apache 2.0) as MinIO replacement with scoped S3 accounts (admin, velero, barman) auto-generated at deploy time — no Doppler secrets needed
- Add `velero-seaweedfs` module with Velero v12.0.0 / plugin-for-aws v1.14.0 pointing at SeaweedFS S3
- Disable minio-operator in k8s-storage, activate velero-seaweedfs
- Add CNPG `plugin-barman-cloud` v0.5.0 to replace deprecated native barman ObjectStore support
- Extend `chart-cnpg-instance` with `ObjectStore` CR template and `plugins` spec support
- Update Temporal CNPG instance to use plugin-based WAL archiving to `s3://cnpg-temporal/`

## Test plan
- [x] SeaweedFS deploys with master, volume, filer, S3 gateway all healthy
- [x] Scoped S3 accounts created and stored in `seaweedfs-s3-accounts` secret
- [x] Velero v12.0.0 deployed with seaweedfs backend using velero-scoped credentials
- [x] Barman cloud plugin running in cnpg-system (v0.11.0)
- [x] Temporal CNPG instance has barman sidecar (2/2 containers)
- [x] ContinuousArchiving condition: `True` — WALs streaming to seaweedfs
- [x] No deprecation warnings from CNPG operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)