### PR TITLE
Pin GitHub Actions to SHA digests via ratchet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       distro: ${{ steps.read-matrix.outputs.distro }}
       build-matrix: ${{ steps.expand-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: read platform-matrix-v1.json
         id: read-matrix
         run: echo "distro=$(jq -cr '@json' < platform-matrix-v1.json)" >> $GITHUB_OUTPUT
@@ -46,7 +46,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare-matrix.outputs.build-matrix) }}
     runs-on: ${{ matrix.RUNNER }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Install Dagger
         run: cd /usr/local && curl -fsSL https://dl.dagger.io/dagger/install.sh | sudo sh
       - name: Publish arch-specific image
@@ -75,13 +75,13 @@ jobs:
         distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
       - name: Create and push manifest list
         env:
           OS: ${{ matrix.distro.OS }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       build-matrix: ${{ steps.expand-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: expand matrix for per-arch builds
         id: expand-matrix
         run: |
@@ -36,7 +36,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare-matrix.outputs.build-matrix) }}
     runs-on: ${{ matrix.RUNNER }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Install Dagger
         run: cd /usr/local && curl -fsSL https://dl.dagger.io/dagger/install.sh | sudo sh
       - name: Validate build (no push)


### PR DESCRIPTION
## Summary
- Pin all GHA action references to immutable SHA digests using [ratchet](https://github.com/sethvargo/ratchet)
- Version tags preserved in `# ratchet:` comments for readability
- Pinned: `actions/checkout@v6`, `docker/login-action@v4`, `docker/setup-buildx-action@v4`

## Test plan
- [ ] PR validation workflow runs with pinned SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)