### PR TITLE
Require explicit kubeconfig + kube_context for all cluster-touching tasks

### DIFF
--- a/antrea.yml
+++ b/antrea.yml
@@ -8,6 +8,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       f: '{{ .antrea_mirror }}/v{{ .antrea_ver }}/antrea.yml'
 tasks:
   default:

--- a/apache-airflow.yml
+++ b/apache-airflow.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: airflow
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: apache-airflow
       chart: airflow
       chart_ver: 1.16.0

--- a/arc.yml
+++ b/arc.yml
@@ -6,11 +6,15 @@ includes:
   kk-controller:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: arc-systems
 #      labels: 'istio.io/dataplane-mode=ambient'
   helm-controller:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: arc-systems
       install: 'true'
       name: arc
@@ -20,11 +24,15 @@ includes:
   kk-runners:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: arc-runners
 #      labels: 'istio.io/dataplane-mode=ambient'
   helm-runners:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: arc-runners
       install: 'true'
       name: arc-runner-set

--- a/argo-raw.yml
+++ b/argo-raw.yml
@@ -4,6 +4,9 @@ includes:
   kubectl:
     taskfile: kubectl.yml
     internal: true
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
 tasks:
   apply:
     vars:

--- a/argo-release.yml
+++ b/argo-release.yml
@@ -4,9 +4,14 @@ includes:
   repo: argo-repo.yml
   kk:
     taskfile: kubectl.yml
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: argo
 tasks:
   upgrade:

--- a/artifacthub.yml
+++ b/artifacthub.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: artifact-hub
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: artifact-hub
       chart: artifact-hub
       chart_ver: 1.22.0

--- a/artifactory-oss.yml
+++ b/artifactory-oss.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: artifactory
       labels: 'istio.io/dataplane-mode=ambient'
   pg-secret:
@@ -14,6 +16,8 @@ includes:
   pg:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: artifactory
       name: artifactory-pg
       chart: chart-cnpg-instance
@@ -28,6 +32,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: artifactory
       name: artifactory
       chart_repo_name: jfrog

--- a/atlas.yml
+++ b/atlas.yml
@@ -4,6 +4,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: oci://ghcr.io/ariga/charts
       chart: atlas-operator
       chart_ver: 0.5.0

--- a/awx-operator.yml
+++ b/awx-operator.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: awx-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: awx-operator
       name: awx-operator
       chart_repo_name: awx-operator

--- a/bazel-buildfarm.yml
+++ b/bazel-buildfarm.yml
@@ -4,6 +4,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: bazel-buildfarm
       create_namespace: 'true'
       install: 'true'

--- a/blackduck.yml
+++ b/blackduck.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: synopsys
       chart: blackduck
       chart_ver: 2024.7.1

--- a/blue-agent.yml
+++ b/blue-agent.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: blue-agent
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: blue-agent
       name: blue-agent
       chart_repo_name: blue-agent

--- a/calico.yml
+++ b/calico.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: projectcalico
       chart: tigera-operator
       chart_ver: v3.31.3

--- a/capi-operator.yml
+++ b/capi-operator.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: capi-operator-system
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: capi-operator-system
       chart_repo_name: capi-operator
       chart: cluster-api-operator

--- a/capsule.yml
+++ b/capsule.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: capsule-system
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: capsule-system
       name: capsule
       chart_repo_name: clastix

--- a/cartographer.yml
+++ b/cartographer.yml
@@ -4,6 +4,8 @@ includes:
   kubectl:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cartographer-system
 tasks:
   install:

--- a/cass-operator.yml
+++ b/cass-operator.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cass-operator
       labels: 'istio.io/dataplane-mode=ambient'
       k: cassandra-cluster
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cass-operator
       name: cass-operator
       chart_repo_name: k8ssandra

--- a/cert-manager.yml
+++ b/cert-manager.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cert-manager
       labels: 'istio.io/dataplane-mode=ambient'
       k: cert-manager
@@ -19,6 +21,8 @@ includes:
   cm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cert-manager
       name: cert-manager
       chart_repo_name: jetstack
@@ -29,6 +33,8 @@ includes:
   approver_policy:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cert-manager
       name: cert-manager-approver-policy
       chart_repo_name: jetstack
@@ -38,6 +44,8 @@ includes:
   csi_driver:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cert-manager
       name: cert-manager-csi-driver
       chart_repo_name: jetstack
@@ -46,6 +54,8 @@ includes:
   trust_manager:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cert-manager
       name: trust-manager
       chart_repo_name: jetstack

--- a/chaos-mesh.yml
+++ b/chaos-mesh.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: chaos-mesh
       labels: 'istio.io/dataplane-mode=ambient'
   ingress:
@@ -16,6 +18,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: chaos-mesh
       chart: chaos-mesh
       chart_ver: 2.8.1

--- a/cilium.yml
+++ b/cilium.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kube-system
       name: cilium
       chart_repo_name: cilium

--- a/clickhouse-instance.yml
+++ b/clickhouse-instance.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: clickhouse-instance
       labels: 'istio.io/dataplane-mode=ambient'
       k: clickhouse-instance

--- a/clickhouse-operator.yml
+++ b/clickhouse-operator.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: clickhouse-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: clickhouse-operator
       chart: altinity-clickhouse-operator
       chart_ver: 0.26.3

--- a/cnpg.yml
+++ b/cnpg.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cnpg-system
       labels: istio.io/dataplane-mode=ambient
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: cnpg
       chart: cloudnative-pg
       chart_ver: 0.28.0
@@ -19,6 +23,8 @@ includes:
   barman-cloud:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: cnpg
       chart: plugin-barman-cloud
       chart_ver: 0.6.0
@@ -27,6 +33,8 @@ includes:
   test-instance:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart: chart-cnpg-instance
       namespace: cnpg-system
       name: test-cnpg-instance

--- a/cockroachdb.yml
+++ b/cockroachdb.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cockroachdb
 #      labels: 'istio.io/dataplane-mode=ambient'
       f: cockroachdb-issuer.yml
@@ -12,6 +14,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cockroachdb
       name: my-cockroachdb
       chart_repo_name: cockroachdb

--- a/coderv2.yml
+++ b/coderv2.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: coder
 #      labels: istio.io/dataplane-mode=ambient
   pg-secret:
@@ -15,6 +17,8 @@ includes:
   pg:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: coder
       name: coder-pg
       chart: chart-cnpg-instance
@@ -27,6 +31,8 @@ includes:
   coderv2:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: coder-v2
       chart: coder
       chart_ver: 2.32.1

--- a/confluence.yml
+++ b/confluence.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       create_namespace: 'true'
       install: 'true'
       namespace: confluence

--- a/conjur-oss.yml
+++ b/conjur-oss.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: conjur-oss
       labels: 'istio.io/dataplane-mode=ambient'
   repo: cyberark.yml
@@ -11,6 +13,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: conjur-oss
       name: conjur-oss
       chart_repo_name: cyberark

--- a/coredns.yml
+++ b/coredns.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: coredns
       chart: coredns
       chart_ver: 1.45.2

--- a/crossplane-aws-provider.yml
+++ b/crossplane-aws-provider.yml
@@ -5,6 +5,8 @@ includes:
     flatten: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
       k: crossplane-aws-provider
 tasks:

--- a/crossplane-aws.yml
+++ b/crossplane-aws.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-aws
       k: crossplane-aws
 tasks:

--- a/crossplane-azure-provider.yml
+++ b/crossplane-azure-provider.yml
@@ -5,6 +5,8 @@ includes:
     flatten: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
       k: crossplane-azure-provider
 tasks:

--- a/crossplane-azure.yml
+++ b/crossplane-azure.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
       k: crossplane-azure
   secret:

--- a/crossplane-gcp-provider.yml
+++ b/crossplane-gcp-provider.yml
@@ -5,6 +5,8 @@ includes:
     flatten: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
       k: crossplane-gcp-provider
 tasks:

--- a/crossplane-gcp.yml
+++ b/crossplane-gcp.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-gcp
       k: crossplane-gcp
 tasks:

--- a/crossplane-terraform-provider.yml
+++ b/crossplane-terraform-provider.yml
@@ -5,6 +5,8 @@ includes:
     flatten: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
       k: crossplane-terraform-provider
 tasks:

--- a/crossplane-terraform.yml
+++ b/crossplane-terraform.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-terraform
       k: crossplane-terraform
 tasks:

--- a/crossplane-vault-provider.yml
+++ b/crossplane-vault-provider.yml
@@ -5,6 +5,8 @@ includes:
     flatten: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
       k: crossplane-vault-provider
 tasks:

--- a/crossplane-vault.yml
+++ b/crossplane-vault.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-vault
       k: crossplane-vault
 tasks:

--- a/crossplane.yml
+++ b/crossplane.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: crossplane-system
 #      labels: istio.io/dataplane-mode=ambient
   crossplane-helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: crossplane-system
       name: crossplane
       chart_repo_name: crossplane-stable

--- a/csi-driver-nfs.yml
+++ b/csi-driver-nfs.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: csi-driver-nfs
       chart: csi-driver-nfs
       chart_ver: 4.13.2

--- a/csi-driver-smb.yml
+++ b/csi-driver-smb.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: csi-driver-smb
       chart: csi-driver-smb
       chart_ver: 1.20.1

--- a/cubefs.yml
+++ b/cubefs.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cubefs
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cubefs
       name: cubefs
       chart_repo_name: cubefs

--- a/dagger-helm.yml
+++ b/dagger-helm.yml
@@ -4,6 +4,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: dagger
       create_namespace: 'true'
       install: 'true'

--- a/datadog.yml
+++ b/datadog.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: datadog
       labels: 'istio.io/dataplane-mode=ambient'
   datadog-secret:
@@ -16,6 +18,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: datadog
       name: datadog
       chart_repo_name: datadog

--- a/debezium-operator.yml
+++ b/debezium-operator.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: debezium-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: debezium
       chart: debezium-operator
       # curl -sSLf https://charts.debezium.io/index.yaml | less

--- a/dragonfly.yml
+++ b/dragonfly.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: dragonfly-system
 # failed on 25-JAN-2026
 #      labels: istio.io/dataplane-mode=ambient
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: dragonfly
       chart: dragonfly
       chart_ver: 1.6.23

--- a/drone.yml
+++ b/drone.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: drone
       chart: drone
       chart_ver: 0.6.5

--- a/druid-operator.yml
+++ b/druid-operator.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: datainfra
       chart: druid-operator
       chart_ver: 0.4.0

--- a/eck.yml
+++ b/eck.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: elastic-system
 #      labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: elastic
       chart: eck-operator
       chart_ver: 3.3.0

--- a/elk.yml
+++ b/elk.yml
@@ -4,6 +4,8 @@ includes:
   elk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: elk
 #      labels: 'istio.io/dataplane-mode=ambient'
       k: elk

--- a/envoygateway.yml
+++ b/envoygateway.yml
@@ -10,11 +10,15 @@ includes:
   gwkk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: envoy-gateway-system
       labels: 'istio.io/dataplane-mode=ambient'
   gw-crds:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: envoy-gateway-system
       name: envoy-gateway-crds
       chart_repo_name: oci://docker.io/envoyproxy
@@ -25,6 +29,8 @@ includes:
   gw:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: envoy-gateway-system
       name: envoy-gateway
       chart_repo_name: oci://docker.io/envoyproxy
@@ -35,11 +41,15 @@ includes:
   aigwkk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: envoy-ai-gateway-system
       labels: 'istio.io/dataplane-mode=ambient'
   aigw-crds:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: envoy-ai-gateway-system
       name: aieg-crds
       chart_repo_name: oci://docker.io/envoyproxy
@@ -49,6 +59,8 @@ includes:
   aigw:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: envoy-ai-gateway-system
       name: aieg
       chart_repo_name: oci://docker.io/envoyproxy

--- a/eraser.yml
+++ b/eraser.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: eraser-system
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: eraser-system
       name: eraser
       chart_repo_name: eraser

--- a/external-dns.yml
+++ b/external-dns.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: external-dns
   secrets:
     taskfile: k8s-literal-secret.yml
@@ -13,6 +15,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: external-dns
       create_namespace: 'false'
       name: external-dns

--- a/external-secrets.yml
+++ b/external-secrets.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: external-secrets
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: external-secrets
       chart: external-secrets
       chart_ver: 2.0.0

--- a/fleet.yml
+++ b/fleet.yml
@@ -7,11 +7,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: cattle-fleet-system
       labels: 'istio.io/dataplane-mode=ambient'
   fleet-crd:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cattle-fleet-system
       name: fleet-crd
       chart_repo_name: fleet
@@ -21,6 +25,8 @@ includes:
   fleet:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: cattle-fleet-system
       name: fleet
       chart_repo_name: fleet

--- a/flink-operator.yml
+++ b/flink-operator.yml
@@ -8,6 +8,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: flink-operator
       create_namespace: 'true'
       install: 'true'
@@ -16,6 +18,8 @@ includes:
   k:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: flink-operator
 tasks:
   default:

--- a/flux.yml
+++ b/flux.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: flux-system
 #      labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: fluxcd-community
       chart: flux2
       chart_ver: 2.18.3

--- a/gatekeeper.yml
+++ b/gatekeeper.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: gatekeeper-system
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: gatekeeper-system
       name: gatekeeper
       chart_repo_name: gatekeeper

--- a/gateway-api.yml
+++ b/gateway-api.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       server_side: "true"
       # check here: https://github.com/kubernetes-sigs/gateway-api/releases
       f: https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml

--- a/gitea.yml
+++ b/gitea.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: gitea
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: gitea-charts
       chart: gitea
       chart_ver: 12.2.0
@@ -19,6 +23,8 @@ includes:
   pg:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: gitea
       name: gitea-pg
       chart: chart-cnpg-instance

--- a/gitlab.yml
+++ b/gitlab.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: gitlab
       labels: 'istio.io/dataplane-mode=ambient'
   pg-secret:
@@ -15,6 +17,8 @@ includes:
   pg:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: gitlab
       name: gitlab-pg
       chart: chart-cnpg-instance
@@ -32,6 +36,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: gitlab
       name: gitlab
       chart_repo_name: gitlab

--- a/gloo-gateway.yml
+++ b/gloo-gateway.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: gloo-system
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: gloo
       chart: gloo
       chart_ver: 1.20.9

--- a/grafana.yml
+++ b/grafana.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: grafana
       labels: 'istio.io/dataplane-mode=ambient'
   alloy:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: grafana
       name: alloy
       chart_repo_name: grafana
@@ -18,6 +22,8 @@ includes:
   grafana:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: grafana
       name: grafana
       chart_repo_name: grafana

--- a/harbor.yml
+++ b/harbor.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: harbor
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: harbor
       name: harbor
       chart_repo_name: harbor

--- a/hatchet.yml
+++ b/hatchet.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: hatchet
   pg-secret:
     taskfile: k8s-literal-secret.yml
@@ -14,6 +16,8 @@ includes:
   pg:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: hatchet
       name: hatchet-pg
       chart: chart-cnpg-instance
@@ -26,6 +30,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: hatchet
       chart: hatchet-stack
       chart_ver: 0.10.5

--- a/hazelcast.yml
+++ b/hazelcast.yml
@@ -6,11 +6,15 @@ includes:
     taskfile: kubectl.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: hazelcast
   platform-operator:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: hazelcast
       name: operator
       chart_repo_name: hazelcast

--- a/helm.yml
+++ b/helm.yml
@@ -1,6 +1,34 @@
 ---
 version: '3'
+
+# Cluster safety
+# --------------
+# Every task that hits a Kubernetes cluster requires the driver to declare
+# both the kubeconfig file and the context, either by passing
+# kubeconfig=<file> kube_context=<name> on the CLI or by exporting
+# KUBECONFIG and KUBE_CONTEXT in the shell. Missing either is a hard error.
+# The flags --kubeconfig and --kube-context are passed on every helm
+# invocation, so current-context drift cannot select the wrong cluster.
+
 tasks:
+  _require-context:
+    internal: true
+    vars:
+      kubeconfig: '{{ .kubeconfig }}'
+      kube_context: '{{ .kube_context }}'
+    cmds:
+      - |-
+        missing=
+        [ -n {{ .kubeconfig | quote }} ]   || missing="${missing}kubeconfig "
+        [ -n {{ .kube_context | quote }} ] || missing="${missing}kube_context "
+        if [ -n "${missing}" ]; then
+          echo "ERROR: helm task requires explicit ${missing}declaration." >&2
+          echo "  Pass kubeconfig=<file> kube_context=<name> on the CLI, or" >&2
+          echo "  export KUBECONFIG=<file> KUBE_CONTEXT=<name> in your shell." >&2
+          echo "  This is enforced repo-wide to prevent cross-cluster mishaps." >&2
+          exit 1
+        fi
+
   check:
     vars:
       chart_repo_name: '{{ .chart_repo_name }}'
@@ -22,6 +50,8 @@ tasks:
         fi
   upgrade:
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       install: '{{ .install | default "true" }}'
       namespace: '{{ .namespace }}'
       create_namespace: '{{ .create_namespace | default "false" }}'
@@ -35,8 +65,14 @@ tasks:
       skip_crds: '{{ .skip_crds | default "false" }}'
       helm_args: '{{ .helm_args | default "" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           upgrade
           {{- if .namespace }} \
           -n {{ .namespace | quote }}
@@ -68,6 +104,8 @@ tasks:
   template-apply:
     desc: "Render chart with helm template and apply via kubectl server-side apply (bypasses release Secret size limit)"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: '{{ .namespace }}'
       name: '{{ .name }}'
       chart_repo_name: '{{ .chart_repo_name }}'
@@ -75,8 +113,14 @@ tasks:
       chart_ver: '{{ .chart_ver }}'
       helm_args: '{{ .helm_args | default "" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           template \
           {{ .name | quote }} \
           "{{ if .chart_repo_name }}{{ .chart_repo_name }}/
@@ -90,10 +134,15 @@ tasks:
           {{- if .helm_args }} \
           {{ .helm_args }}
           {{- end }} \
-          | kubectl apply --server-side --force-conflicts -f -
+          | kubectl \
+              --kubeconfig {{ .kubeconfig | quote }} \
+              --context {{ .kube_context | quote }} \
+              apply --server-side --force-conflicts -f -
   template-delete:
     desc: "Render chart with helm template and delete via kubectl"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: '{{ .namespace }}'
       name: '{{ .name }}'
       chart_repo_name: '{{ .chart_repo_name }}'
@@ -101,8 +150,14 @@ tasks:
       chart_ver: '{{ .chart_ver }}'
       helm_args: '{{ .helm_args | default "" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           template \
           {{ .name | quote }} \
           "{{ if .chart_repo_name }}{{ .chart_repo_name }}/
@@ -116,9 +171,14 @@ tasks:
           {{- if .helm_args }} \
           {{ .helm_args }}
           {{- end }} \
-          | kubectl delete --ignore-not-found -f -
+          | kubectl \
+              --kubeconfig {{ .kubeconfig | quote }} \
+              --context {{ .kube_context | quote }} \
+              delete --ignore-not-found -f -
   install:
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: '{{ .namespace }}'
       create_namespace: '{{ .create_namespace | default "false" }}'
       name: '{{ .name }}'
@@ -129,8 +189,14 @@ tasks:
       timeout: '{{ .timeout | default "10m" }}'
       helm_args: '{{ .helm_args | default "" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           install
           {{- if .namespace }} \
           -n {{ .namespace | quote }}
@@ -153,18 +219,24 @@ tasks:
     status:
       - |
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           list \
           -n {{ .namespace | quote }} \
           -o json \
           | jq -e '.[] | select(.name=={{ .name | quote }})'
   delete:
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: '{{ .namespace }}'
       name: '{{ .name }}'
       wait: '{{ .wait | default "true" }}'
     preconditions:
       - |
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           list
           {{- if .namespace }} \
           -n {{ .namespace | quote }}
@@ -172,8 +244,14 @@ tasks:
           -o json \
           | jq -e '.[] | select(.name=={{ .name | quote }})'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
         helm \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --kube-context {{ .kube_context | quote }} \
           delete
           {{- if .namespace }} \
           -n {{ .namespace | quote }}

--- a/ingress-nginx.yml
+++ b/ingress-nginx.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: ingress-nginx
       create_namespace: 'true'
       install: 'true'

--- a/ipsec-vpn-server.yml
+++ b/ipsec-vpn-server.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: ipsec-vpn-server
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: taskmedia
       chart: ipsec-vpn-server
       chart_ver: 2.2.0

--- a/istio.yml
+++ b/istio.yml
@@ -7,6 +7,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: istio-system
       create_namespace: 'true'
       name: istio-ambient

--- a/jaeger.yml
+++ b/jaeger.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: jaegertracing
       chart: jaeger
       chart_ver: 4.7.0

--- a/jira.yml
+++ b/jira.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       create_namespace: 'true'
       install: 'true'
       namespace: jira

--- a/juicefs.yml
+++ b/juicefs.yml
@@ -5,6 +5,8 @@ includes:
   csi-driver:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: juicefs
       chart: juicefs-csi-driver
       chart_ver: 0.19.8
@@ -14,6 +16,8 @@ includes:
   s3-gateway:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: juicefs
       chart: juicefs-s3-gateway
       chart_ver: 0.11.2

--- a/k0smotron.yml
+++ b/k0smotron.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       f: https://docs.k0smotron.io/stable/install.yaml
 tasks:
   default:

--- a/k3d.yml
+++ b/k3d.yml
@@ -5,6 +5,8 @@ includes:
     internal: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kube-system
 tasks:
   wait_for_ready:

--- a/k8s-dashboard.yml
+++ b/k8s-dashboard.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       create_namespace: 'true'
       install: 'true'
       namespace: kubernetes-dashboard

--- a/k8s-digester.yml
+++ b/k8s-digester.yml
@@ -16,6 +16,8 @@ includes:
     internal: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: digester-system
 tasks:
   default:

--- a/k8sgpt.yml
+++ b/k8sgpt.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: k8sgpt-operator-system
       labels: 'istio.io/dataplane-mode=ambient'
       k: k8sgpt-ollama-backend
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: k8sgpt
       chart: k8sgpt-operator
       chart_ver: 0.2.25

--- a/kargo.yml
+++ b/kargo.yml
@@ -13,11 +13,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kargo
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kargo
       chart_repo_name: "oci://ghcr.io/akuity/kargo-charts"
       chart: kargo

--- a/keda.yml
+++ b/keda.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: keda
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: keda
       name: keda
       chart_repo_name: kedacore

--- a/keycloak-operator.yml
+++ b/keycloak-operator.yml
@@ -11,6 +11,8 @@ includes:
     internal: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: keycloak-operator
       labels: istio.io/dataplane-mode=ambient
   gh:

--- a/kiali.yml
+++ b/kiali.yml
@@ -9,6 +9,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: kiali
       chart: kiali-operator
       chart_ver: 2.25.0

--- a/knative.yml
+++ b/knative.yml
@@ -5,11 +5,15 @@ includes:
     taskfile: kubectl.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       k: knative-operator
   crs:
     taskfile: kubectl.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       k: knative
 tasks:
   default:

--- a/komodor.yml
+++ b/komodor.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: komodorio
       chart: komodor-agent
       chart_ver: 2.15.3

--- a/koordinator.yml
+++ b/koordinator.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: koordinator-sh
       chart: koordinator
       chart_ver: 1.7.0

--- a/kpack.yml
+++ b/kpack.yml
@@ -5,6 +5,8 @@ includes:
     internal: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kpack
       k: kpack
 tasks:

--- a/kro.yml
+++ b/kro.yml
@@ -9,11 +9,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kro
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kro
       name: kro
       chart_repo_name: "oci://registry.k8s.io/kro/charts"

--- a/kube-prometheus-stack.yml
+++ b/kube-prometheus-stack.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kube-prometheus-stack
       labels: istio.io/dataplane-mode=ambient
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kube-prometheus-stack
       name: kube-prometheus-stack
       chart_repo_name: prometheus-community

--- a/kubeai.yml
+++ b/kubeai.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kubeai
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kubeai
       name: kubeai
       chart_repo_name: kubeai

--- a/kubectl.yml
+++ b/kubectl.yml
@@ -1,21 +1,57 @@
 ---
 version: '3'
 
+# Cluster safety
+# --------------
+# Every task that hits a Kubernetes cluster requires the driver to declare
+# both the kubeconfig file and the context, either by passing
+# kubeconfig=<file> kube_context=<name> on the CLI or by exporting
+# KUBECONFIG and KUBE_CONTEXT in the shell. Missing either is a hard error.
+# The flags --kubeconfig and --context are passed on every kubectl
+# invocation, so current-context drift cannot select the wrong cluster.
+
 vars:
   KUBECTL_TIMEOUT: '{{ .KUBECTL_TIMEOUT | default "300s" }}'
   KUBECTL_DRY_RUN: '{{ .KUBECTL_DRY_RUN | default "false" }}'
 
 tasks:
+  _require-context:
+    internal: true
+    vars:
+      kubeconfig: '{{ .kubeconfig }}'
+      kube_context: '{{ .kube_context }}'
+    cmds:
+      - |-
+        missing=
+        [ -n {{ .kubeconfig | quote }} ]   || missing="${missing}kubeconfig "
+        [ -n {{ .kube_context | quote }} ] || missing="${missing}kube_context "
+        if [ -n "${missing}" ]; then
+          echo "ERROR: kubectl task requires explicit ${missing}declaration." >&2
+          echo "  Pass kubeconfig=<file> kube_context=<name> on the CLI, or" >&2
+          echo "  export KUBECONFIG=<file> KUBE_CONTEXT=<name> in your shell." >&2
+          echo "  This is enforced repo-wide to prevent cross-cluster mishaps." >&2
+          exit 1
+        fi
+
   ns-label:
     desc: "Apply labels to a namespace"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       labels: '{{ .labels }}'
       overwrite: '{{ .overwrite | default "true" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
         {{- if .labels }}
-        kubectl label \
+        kubectl \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --context {{ .kube_context | quote }} \
+          label \
           namespace \
           {{ .n | quote }} \
           {{ .labels | quote }}
@@ -29,24 +65,35 @@ tasks:
   ns-create:
     desc: "Create a namespace"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       labels: '{{ .labels }}'
       dry_run: '{{ .dry_run | default .KUBECTL_DRY_RUN }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
-        kubectl create \
+        kubectl \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --context {{ .kube_context | quote }} \
+          create \
           namespace {{ .n | quote }}
         {{- if eq "true" .dry_run }} \
           --dry-run=client
         {{- end }}
       - task: ns-label
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           n: '{{ .n }}'
           labels: '{{ .labels }}'
     status:
       - >-
         {{- if ne "true" .dry_run }}
-        kubectl get namespace {{ .n | quote }}
+        kubectl --kubeconfig {{ .kubeconfig | quote }} --context {{ .kube_context | quote }} get namespace {{ .n | quote }}
         {{- else }}
         false
         {{- end }}
@@ -54,11 +101,20 @@ tasks:
   ns-delete:
     desc: "Delete a namespace"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       force: '{{ .force | default "false" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
-        kubectl delete \
+        kubectl \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --context {{ .kube_context | quote }} \
+          delete \
           namespace {{ .n | quote }}
         {{- if eq .force "true" }} \
           --force --grace-period=0
@@ -67,6 +123,8 @@ tasks:
   _apply:
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       verb: '{{ .verb }}'
       n: '{{ .n }}'
       f: '{{ .f }}'
@@ -76,8 +134,15 @@ tasks:
       force: '{{ .force | default "false" }}'
       validate: '{{ .validate | default "true" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
-          kubectl {{ .verb }}
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            {{ .verb }}
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }}
@@ -103,6 +168,8 @@ tasks:
   create:
     desc: "Create resources from file"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       f: '{{ .f }}'
       literal_f: '{{ .literal_f }}'
@@ -111,6 +178,8 @@ tasks:
     cmds:
       - task: _apply
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           verb: create
           n: '{{ .n }}'
           f: '{{ .f }}'
@@ -121,6 +190,8 @@ tasks:
   apply:
     desc: "Apply resources from file"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       f: '{{ .f }}'
       literal_f: '{{ .literal_f }}'
@@ -130,6 +201,8 @@ tasks:
     cmds:
       - task: _apply
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           verb: apply
           n: '{{ .n }}'
           f: '{{ .f }}'
@@ -141,6 +214,8 @@ tasks:
   delete:
     desc: "Delete resources from file"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       f: '{{ .f }}'
       literal_f: '{{ .literal_f }}'
@@ -149,6 +224,8 @@ tasks:
     cmds:
       - task: _apply
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           verb: delete
           n: '{{ .n }}'
           f: '{{ .f }}'
@@ -158,13 +235,22 @@ tasks:
   kapply:
     desc: "Apply kustomization"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       k: '{{ .k }}'
       server_side: '{{ .server_side | default "false" }}'
       dry_run: '{{ .dry_run | default .KUBECTL_DRY_RUN }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
-          kubectl apply
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            apply
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }}
@@ -181,12 +267,21 @@ tasks:
   kdelete:
     desc: "Delete kustomization"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       k: '{{ .k }}'
       force: '{{ .force | default "false" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
-          kubectl delete
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            delete
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }} \
@@ -198,6 +293,8 @@ tasks:
   patch:
     desc: "Patch a resource"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n | default "default" }}'
       resource: '{{ .resource }}{{ .typeofthing }}'  # Support both names
       name: '{{ .name }}{{ .thingname }}'
@@ -205,8 +302,15 @@ tasks:
       patch: '{{ .patch }}'
       dry_run: '{{ .dry_run | default .KUBECTL_DRY_RUN }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
-          kubectl patch
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            patch
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }} \
@@ -221,6 +325,8 @@ tasks:
   wait:
     desc: "Wait for resource condition"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       resource: '{{ .resource }}'
       name: '{{ .name }}'
@@ -228,8 +334,15 @@ tasks:
       for: '{{ .for | default "condition=ready" }}'
       timeout: '{{ .timeout | default .KUBECTL_TIMEOUT }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
-          kubectl wait
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            wait
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }} \
@@ -246,6 +359,8 @@ tasks:
   wait-for-pod:
     desc: "Wait for pod condition"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       for: '{{ .for | default "condition=ready" }}'
       n: '{{ .n }}'
       k: '{{ .k }}'
@@ -254,6 +369,8 @@ tasks:
     cmds:
       - task: wait
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           n: '{{ .n }}'
           resource: pod
           selector: '{{ .k }}={{ .v }}'
@@ -263,12 +380,16 @@ tasks:
   wait-for-pod-ready:
     desc: "Wait for pod to be ready"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       k8s_app: '{{ .k8s_app }}'
       timeout: '{{ .timeout | default .KUBECTL_TIMEOUT }}'
     cmds:
       - task: wait-for-pod
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           for: condition=ready
           n: '{{ .n }}'
           k: k8s-app
@@ -278,12 +399,16 @@ tasks:
   wait-for-deployment:
     desc: "Wait for deployment to be ready"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       name: '{{ .name }}'
       timeout: '{{ .timeout | default .KUBECTL_TIMEOUT }}'
     cmds:
       - task: wait
         vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
           n: '{{ .n }}'
           resource: deployment
           name: '{{ .name }}'
@@ -293,13 +418,22 @@ tasks:
   rollout-status:
     desc: "Check rollout status"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       resource: '{{ .resource | default "deployment" }}'
       name: '{{ .name }}'
       timeout: '{{ .timeout | default .KUBECTL_TIMEOUT }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
-          kubectl rollout status
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            rollout status
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }} \
@@ -309,12 +443,21 @@ tasks:
   rollout-restart:
     desc: "Restart a rollout"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       resource: '{{ .resource | default "deployment" }}'
       name: '{{ .name }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
-        kubectl rollout restart
+        kubectl \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --context {{ .kube_context | quote }} \
+          rollout restart
         {{- if .n }} \
           -n {{ .n | quote }}
         {{- end }} \
@@ -323,13 +466,22 @@ tasks:
   scale:
     desc: "Scale a resource"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       resource: '{{ .resource | default "deployment" }}'
       name: '{{ .name }}'
       replicas: '{{ .replicas }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
-        kubectl scale
+        kubectl \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --context {{ .kube_context | quote }} \
+          scale
         {{- if .n }} \
           -n {{ .n | quote }}
         {{- end }} \
@@ -338,14 +490,23 @@ tasks:
   exec:
     desc: "Execute command in pod"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       pod: '{{ .pod }}'
       container: '{{ .container }}'
       cmd: '{{ .cmd | default "sh" }}'
       interactive: '{{ .interactive | default "true" }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |-
-          kubectl exec
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            exec
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }}
@@ -360,6 +521,8 @@ tasks:
   logs:
     desc: "Get pod logs"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       pod: '{{ .pod }}'
       container: '{{ .container }}'
@@ -367,8 +530,15 @@ tasks:
       tail: '{{ .tail }}'
       since: '{{ .since }}'
     cmds:
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
       - |
-          kubectl logs
+          kubectl \
+            --kubeconfig {{ .kubeconfig | quote }} \
+            --context {{ .kube_context | quote }} \
+            logs
           {{- if .n }} \
             -n {{ .n | quote }}
           {{- end }}
@@ -389,12 +559,21 @@ tasks:
   port-forward:
     desc: "Forward ports to a pod"
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: '{{ .n }}'
       resource: '{{ .resource | default "pod" }}'
       name: '{{ .name }}'
       ports: '{{ .ports }}'
     cmds:
-      - kubectl port-forward
+      - task: _require-context
+        vars:
+          kubeconfig: '{{ .kubeconfig }}'
+          kube_context: '{{ .kube_context }}'
+      - kubectl \
+          --kubeconfig {{ .kubeconfig | quote }} \
+          --context {{ .kube_context | quote }} \
+          port-forward
         {{- if .n }} \
           -n {{ .n | quote }}
         {{- end }} \

--- a/kubeflow.yml
+++ b/kubeflow.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kubeflow
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kubeflow
       name: kubeflow
       chart_repo_name: kubeflow

--- a/kubeshark.yml
+++ b/kubeshark.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: kubeshark
       chart: kubeshark
       chart_ver: 52.8.1

--- a/kubevirt-cdi.yml
+++ b/kubevirt-cdi.yml
@@ -3,6 +3,9 @@ version: '3'
 includes:
   kk:
     taskfile: kubectl.yml
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
 tasks:
   apply:
     cmds:

--- a/kubevirt-vm.yml
+++ b/kubevirt-vm.yml
@@ -8,6 +8,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kubevirt-vms
       k: kubevirt-vm
 tasks:

--- a/kubevirt.yml
+++ b/kubevirt.yml
@@ -3,6 +3,9 @@ version: '3'
 includes:
   kk:
     taskfile: kubectl.yml
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
 #    vars:
 #      n: kubevirt
 tasks:

--- a/kyverno.yml
+++ b/kyverno.yml
@@ -5,10 +5,14 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kyverno
   kyverno:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kyverno
       name: kyverno
       chart_repo_name: kyverno
@@ -18,6 +22,8 @@ includes:
   kyverno_policies:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kyverno
       name: kyverno-policies
       chart_repo_name: kyverno

--- a/linstor-cluster.yml
+++ b/linstor-cluster.yml
@@ -5,6 +5,8 @@ includes:
     internal: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: linstor-clusters
       k: linstor-cluster
 tasks:

--- a/litellm-instance.yml
+++ b/litellm-instance.yml
@@ -9,6 +9,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: litellm-instance
       labels: 'istio.io/dataplane-mode=ambient'
       k: litellm-instance

--- a/litellm-operator.yml
+++ b/litellm-operator.yml
@@ -9,11 +9,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: litellm
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: litellm
       name: litellm-operator
       chart_repo_name: "oci://ghcr.io/bbdsoftware/charts"

--- a/litmuschaos.yml
+++ b/litmuschaos.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: litmus
       labels: 'istio.io/dataplane-mode=ambient'
   ingress:
@@ -16,6 +18,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: litmuschaos
       chart: litmus
       chart_ver: 3.25.0

--- a/longhorn.yml
+++ b/longhorn.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: longhorn-system
       create_namespace: 'true'
       name: longhorn

--- a/loxilb.yml
+++ b/loxilb.yml
@@ -27,6 +27,8 @@ includes:
   kube-loxilb:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: kube-system
       f: https://raw.githubusercontent.com/loxilb-io/kube-loxilb/v0.8.3/manifest/kube-loxilb.yaml
 tasks:

--- a/mayastor.yml
+++ b/mayastor.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: startechnica
       chart: mayastor
       chart_ver: 0.2.0

--- a/metallb.yml
+++ b/metallb.yml
@@ -6,12 +6,16 @@ includes:
     taskfile: kubectl.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: metallb-system
       k: metallb-kind
   metallb:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: metallb-system
       name: metallb
       chart_repo_name: metallb

--- a/metrics-server.yml
+++ b/metrics-server.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kube-system
       name: metrics-server
       chart_repo_name: metrics-server

--- a/milvus.yml
+++ b/milvus.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: milvus
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: milvus
       chart: milvus
       chart_ver: 4.0.31

--- a/minio-operator.yml
+++ b/minio-operator.yml
@@ -7,11 +7,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: minio-operator
       labels: istio.io/dataplane-mode=ambient
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: minio
       chart: operator
       chart_ver: 7.1.1

--- a/minio-tenant.yml
+++ b/minio-tenant.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: minio
       chart: tenant
       chart_ver: 7.1.1

--- a/mlflow.yml
+++ b/mlflow.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: mlflow
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: community-charts
       chart: mlflow
       chart_ver: 1.8.1

--- a/mysql-operator.yml
+++ b/mysql-operator.yml
@@ -7,6 +7,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: mysql-operator
       create_namespace: 'true'
       name: mysql-operator
@@ -18,6 +20,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: mysql-clusters
       f: mysql-cluster.yml
   k8s-secret:

--- a/nats.yml
+++ b/nats.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: nats
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: nats
       chart: nats
       chart_ver: 2.12.6

--- a/neo4j.yml
+++ b/neo4j.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: neo4j
       labels: 'istio.io/dataplane-mode=ambient'
   secrets:
@@ -16,6 +18,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: neo4j
       name: neo4j
       chart_repo_name: neo4j

--- a/nginx-ingress.yml
+++ b/nginx-ingress.yml
@@ -4,6 +4,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: nginx-ingress
       upgrade: 'true'
       create_namespace: 'true'

--- a/ngrok-operator.yml
+++ b/ngrok-operator.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: ngrok-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: ngrok
       chart: ngrok-operator
       namespace: ngrok-operator

--- a/open-telemetry-operator.yml
+++ b/open-telemetry-operator.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: otel-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: otel-operator
       name: otel-operator
       chart_repo_name: open-telemetry

--- a/open-webui.yml
+++ b/open-webui.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: open-webui
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: open-webui
       name: open-webui
       chart_repo_name: open-webui

--- a/openbao.yml
+++ b/openbao.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: openbao
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: openbao
       name: openbao
       chart_repo_name: openbao

--- a/opencost.yml
+++ b/opencost.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: opencost
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: opencost
       chart: opencost
       chart_ver: 2.5.8

--- a/openebs.yml
+++ b/openebs.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: openebs
       create_namespace: true
       name: openebs

--- a/orkes-conductor-standalone.yml
+++ b/orkes-conductor-standalone.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: orkes-conductor-standalone
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: orkes-conductor-standalone
       name: conductor
       chart_repo_name: orkes-helm-charts

--- a/piraeus-operator.yml
+++ b/piraeus-operator.yml
@@ -8,6 +8,8 @@ includes:
     internal: true
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: piraeus-datastore
       server_side: "true"
 tasks:

--- a/pomerium-zero.yml
+++ b/pomerium-zero.yml
@@ -5,6 +5,8 @@ includes:
     taskfile: kubectl.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       k: pomerium-zero
   token:
     taskfile: k8s-literal-secret.yml

--- a/prefect.yml
+++ b/prefect.yml
@@ -7,11 +7,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: prefect
       labels: 'istio.io/dataplane-mode=ambient'
   server:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: prefect
       name: prefect-server
       chart_repo_name: prefect
@@ -22,6 +26,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: prefect
       name: prefect-worker
       chart_repo_name: prefect

--- a/pulumi-kubernetes-operator.yml
+++ b/pulumi-kubernetes-operator.yml
@@ -4,6 +4,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart: oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator
       chart_ver: 2.0.0
       create_namespace: "true"

--- a/puppetserver.yml
+++ b/puppetserver.yml
@@ -4,12 +4,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: puppetserver
 #      labels: 'istio.io/dataplane-mode=ambient'
   repo: puppet.yml
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: puppet
       chart: puppetserver
       chart_ver: 9.5.2

--- a/pxc-db.yml
+++ b/pxc-db.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: pxc-db
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: percona
       chart: pxc-db
       chart_ver: 1.19.0

--- a/pxc-operator.yml
+++ b/pxc-operator.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: pxc-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: percona
       chart: pxc-operator
       chart_ver: 1.19.1

--- a/qdrant.yml
+++ b/qdrant.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: qdrant
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: qdrant
       chart: qdrant
       chart_ver: 1.16.3

--- a/questdb.yml
+++ b/questdb.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: questdb
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: questdb
       name: questdb
       chart_repo_name: questdb

--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: redis-cluster
       labels: 'istio.io/dataplane-mode=ambient'
       k: redis-cluster

--- a/redis-operator.yml
+++ b/redis-operator.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: ot-operators
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: ot-helm
       chart: redis-operator
       chart_ver: 0.18.5

--- a/redis-standalone.yml
+++ b/redis-standalone.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: redis-standalone
       labels: 'istio.io/dataplane-mode=ambient'
       k: redis-standalone

--- a/reloader.yml
+++ b/reloader.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: reloader
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: reloader
       name: reloader
       chart_repo_name: stakater

--- a/retool.yml
+++ b/retool.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: retool
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: retool
       name: retool
       chart_repo_name: retool

--- a/rook.yml
+++ b/rook.yml
@@ -7,6 +7,8 @@ includes:
   operator:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: rook-ceph
       create_namespace: 'true'
       name: rook-ceph
@@ -16,6 +18,8 @@ includes:
   cluster:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: rook-ceph-cluster
       create_namespace: 'true'
       name: rook-ceph-cluster

--- a/scylla-operator.yml
+++ b/scylla-operator.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: scylla-operator
       create_namespace: 'true'
       install: 'true'
@@ -16,6 +18,8 @@ includes:
   cluster:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: scylla-clusters
       f: scylla-cluster.yml
 tasks:

--- a/sealed-secrets.yml
+++ b/sealed-secrets.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kube-system
       name: sealed-secrets
       chart_repo_name: sealed-secrets

--- a/seaweedfs.yml
+++ b/seaweedfs.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: seaweedfs
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: seaweedfs
       chart: seaweedfs
       chart_ver: 4.22.0

--- a/secrets-store-csi-driver.yml
+++ b/secrets-store-csi-driver.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: kube-system
       name: csi-secrets-store
       chart_repo_name: secrets-store-csi-driver

--- a/solr-operator.yml
+++ b/solr-operator.yml
@@ -7,12 +7,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: solr-operator
 #      labels: 'istio.io/dataplane-mode=ambient'
       f: https://solr.apache.org/operator/downloads/crds/v{{ .SOLR_VER }}/all.yaml
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: apache-solr
       chart: solr-operator
       chart_ver: '{{ .SOLR_VER }}'
@@ -21,6 +25,8 @@ includes:
   cluster:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: apache-solr
       chart: solr
       chart_ver: '{{ .SOLR_VER }}'

--- a/sonarqube.yml
+++ b/sonarqube.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: sonarqube
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: sonarqube
       chart_repo_name: sonarqube
       chart: sonarqube

--- a/spegel.yml
+++ b/spegel.yml
@@ -4,6 +4,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: spegel
       create_namespace: 'true'
       install: 'true'

--- a/spire.yml
+++ b/spire.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: spire-mgmt
       labels: 'istio.io/dataplane-mode=ambient'
   spire-crds:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: spire
       chart: spire-crds
       chart_ver: 0.5.0
@@ -18,6 +22,8 @@ includes:
   spire:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: spire
       chart: spire
       chart_ver: 0.28.3

--- a/stackgres.yml
+++ b/stackgres.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: stackgres
       create_namespace: 'true'
       install: 'true'

--- a/strimzi-kafka-operator.yml
+++ b/strimzi-kafka-operator.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: strimzi-kafka-operator
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: strimzi-kafka-operator
       chart_repo_name: strimzi
       chart: strimzi-kafka-operator
@@ -21,6 +25,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       name: strimzi-test-kafka-cluster
       chart: chart-strimzi-kafka
 tasks:

--- a/tailscale-ingress.yml
+++ b/tailscale-ingress.yml
@@ -3,6 +3,9 @@ version: '3'
 includes:
   helm:
     taskfile: helm.yml
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
 tasks:
   upgrade:
     vars:

--- a/tailscale.yml
+++ b/tailscale.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: tailscale
 #      labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: tailscale
       chart: tailscale-operator
       chart_ver: 1.96.5

--- a/tekton-pipelines.yml
+++ b/tekton-pipelines.yml
@@ -9,6 +9,8 @@ includes:
   hello-world:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       f: tekton-helloworld.yml
 tasks:
   apply:

--- a/tekton-triggers.yml
+++ b/tekton-triggers.yml
@@ -9,10 +9,14 @@ includes:
   release:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       f: '{{ .TEKTON_TRIGGERS_MIRROR }}/release.yaml'
   interceptors:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       f: '{{ .TEKTON_TRIGGERS_MIRROR }}/interceptors.yaml'
 tasks:
   apply:

--- a/temporal.yml
+++ b/temporal.yml
@@ -5,6 +5,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: temporal
   pg-secret:
     taskfile: k8s-literal-secret.yml
@@ -19,6 +21,8 @@ includes:
   pg:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: temporal
       name: temporal-pg
       chart: chart-cnpg-instance
@@ -43,6 +47,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: temporalio
       chart: temporal
       chart_ver: 1.2.0

--- a/transmission.yml
+++ b/transmission.yml
@@ -10,10 +10,14 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: transmission
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart: chart-transmission
       namespace: transmission
       name: transmission

--- a/transmission.yml
+++ b/transmission.yml
@@ -1,5 +1,11 @@
 ---
 version: '3'
+
+# Cluster targeting is enforced repo-wide in helm.yml and kubectl.yml:
+# the driver MUST declare both kubeconfig and kube_context, either by
+# exporting KUBECONFIG and KUBE_CONTEXT in the shell or by passing
+# kubeconfig=<file> kube_context=<name> on the CLI.
+
 includes:
   kk:
     taskfile: kubectl.yml
@@ -17,15 +23,18 @@ includes:
       namespace: transmission
       name: tailscale-ingress
       helm_args: -f transmission-tailscale-ingress-values.yml
+
 tasks:
   default:
     cmds:
       - task: upgrade
+
   upgrade:
     cmds:
       - task: kk:ns-create
       - task: helm:upgrade
       - task: ingress:upgrade
+
   delete:
     cmds:
       - task: ingress:delete

--- a/trident.yml
+++ b/trident.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: trident-operator
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: trident-operator
       chart_repo_name: netapp-trident
       chart: trident-operator

--- a/trivy-operator.yml
+++ b/trivy-operator.yml
@@ -6,6 +6,8 @@ includes:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: aqua
       chart: trivy-operator
       chart_ver: 0.32.0

--- a/valkey.yml
+++ b/valkey.yml
@@ -8,8 +8,14 @@ includes:
   repo: valkey-repo.yml
   kk:
     taskfile: kubectl.yml
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
   helm:
     taskfile: helm.yml
+    vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
 tasks:
   default:
     deps:

--- a/vault.yml
+++ b/vault.yml
@@ -10,11 +10,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: vault-system
       labels: istio.io/dataplane-mode=ambient
   vault-secrets-operator:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: hashicorp
       chart: vault-secrets-operator
       chart_ver: 1.3.0
@@ -23,6 +27,8 @@ includes:
   vault:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: hashicorp
       chart: vault
       chart_ver: 0.32.0

--- a/vcluster.yml
+++ b/vcluster.yml
@@ -5,10 +5,14 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: loft-sh
       chart: vcluster
       chart_ver: 0.34.0

--- a/velero-seaweedfs.yml
+++ b/velero-seaweedfs.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: velero
       labels: 'istio.io/dataplane-mode=ambient'
   velero-seaweedfs-credentials:
@@ -15,6 +17,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: vmware-tanzu
       chart: velero
       chart_ver: 12.0.0

--- a/velero.yml
+++ b/velero.yml
@@ -4,6 +4,8 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: velero
       labels: 'istio.io/dataplane-mode=ambient'
   minio-tenant:
@@ -26,6 +28,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: vmware-tanzu
       chart: velero
       chart_ver: 12.0.1

--- a/vpa.yml
+++ b/vpa.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: vpa
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: vpa
       name: vpa
       chart_repo_name: cowboysysop

--- a/weaviate-helm.yml
+++ b/weaviate-helm.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: weaviate
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: weaviate
       name: weaviate
       chart_repo_name: weaviate

--- a/wireguard.yml
+++ b/wireguard.yml
@@ -5,12 +5,16 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: wireguard
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     internal: true
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       namespace: wireguard
       name: wireguard
       chart_repo_name: wireguard

--- a/yugabyte.yml
+++ b/yugabyte.yml
@@ -5,11 +5,15 @@ includes:
   kk:
     taskfile: kubectl.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       n: yugabyte
       labels: 'istio.io/dataplane-mode=ambient'
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: yugabytedb
       chart: yugabyte
       chart_ver: 2025.2.1

--- a/zookeeper-operator.yml
+++ b/zookeeper-operator.yml
@@ -5,6 +5,8 @@ includes:
   helm:
     taskfile: helm.yml
     vars:
+      kubeconfig: '{{ .kubeconfig | default (env "KUBECONFIG") }}'
+      kube_context: '{{ .kube_context | default (env "KUBE_CONTEXT") }}'
       chart_repo_name: pravega
       chart: zookeeper-operator
       chart_ver: 0.2.15


### PR DESCRIPTION
## Summary
- `helm.yml` and `kubectl.yml` now hard-require both `kubeconfig` and `kube_context` (CLI vars or `KUBECONFIG`/`KUBE_CONTEXT` env). Missing either aborts with a clear message before any cluster call.
- Every `helm` invocation gets `--kubeconfig <file> --kube-context <ctx>` and every `kubectl` invocation gets `--kubeconfig <file> --context <ctx>` — current-context drift can no longer select the wrong cluster.
- `transmission.yml` drops its local preflight/env machinery; the repo-wide guard now does the job.
- Read-only `helm.yml:check` (queries chart repo, doesn't hit a cluster) is intentionally unchanged.

## Why
Juggling many clusters simultaneously raises the risk of accidentally applying changes to the wrong one. Forcing the driver to declare both pieces explicitly closes the gap where `KUBECONFIG` was set but the kubeconfig's current-context had drifted to something dangerous.

## Behavior change for callers
- Existing taskfiles (`argocd.yml`, `gitea.yml`, etc.) keep working **only when** both env vars are exported. Otherwise they'll abort with a clear message — which is the point.
- Any caller that previously relied on implicit current-context will now refuse until updated to declare `kube_context`.

## Test plan
- [x] `task -t kubectl.yml ns-create n=foo` (no env) → refuses with both-missing error
- [x] `KUBECONFIG=x task -t kubectl.yml ns-create n=foo` → refuses with `kube_context` missing
- [x] `KUBECONFIG=x KUBE_CONTEXT=y task -t kubectl.yml apply ...` → emits `--kubeconfig "x" --context "y"`
- [x] `task ... kubeconfig=a kube_context=b` (CLI override) → emits CLI values
- [x] `task -t helm.yml upgrade ...` mirror tests → flags propagated as `--kubeconfig`/`--kube-context`
- [x] `task -t transmission.yml upgrade` (no env) → refuses via repo-wide guard through include chain
- [x] `uvx pre-commit run --files helm.yml kubectl.yml transmission.yml`
- [ ] End-to-end: real `task argocd:upgrade` against a configured cluster after exporting both env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)